### PR TITLE
Update qemu_copyimage.sh

### DIFF
--- a/qemu_copyimage.sh
+++ b/qemu_copyimage.sh
@@ -25,4 +25,3 @@ if [ -z "$BOOTFILE" ]; then
     exit 1
 fi
 virt-copy-out -a $IMAGE /boot/$BOOTFILE .
-mv $BOOTFILE $COPYTO


### PR DESCRIPTION
28 #mv $BOOTFILE $COPYTO <-- Not needed, I think. The previous like copies the file from the disk image into the host machine current dir which is the same thing as this line.